### PR TITLE
MDK Scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM bitnami/moodle
 # Install related packages and set LLVM 3.6 as the compiler
 RUN apt-get -q update && \
     apt-get -q install -y \
-    unzip python-pip libmysqlclient-dev libpq-dev python-dev git nano
+    unzip python-pip libmysqlclient-dev libpq-dev python-dev git
+RUN curl -L https://github.com/Civil-Service-Human-Resources/docker-moodle-scripts/archive/master.zip > docker-moodle-scripts.zip
 RUN curl https://moodle.org/plugins/download.php/15169/logstore_xapi_moodle34_2017103001.zip > logstore_xapi_moodle34_2017103001.zip
 RUN unzip logstore_xapi_moodle34_2017103001.zip -d opt/bitnami/moodle/admin/tool/log/store
+RUN unzip docker-moodle-scripts.zip -d opt/bitnami/
+RUN rm docker-moodle-scripts.zip && rm logstore_xapi_moodle34_2017103001.zip


### PR DESCRIPTION
related issue: #1 

goto: [tldr](#tldr)

I think most of the scripts from mdk relied on MDK Workspace class (not sure on python terms - sorry!!!) properties to help the scripts run. I think mostly to do with dirs. Since `mdk create` was pulling the official moodle mirror into `dirs.moodles/stable_master/moodle` the py did some checking on this and thats why we got the "This is not a moodle instance" error. so I am not entire convinced that `.php`s will do anything, I didn't really dig into their mechanism. 

It will also be useful for us to have MDK's `plugin` command but did a bunch of MDK moodle validation stuff... "This is not a moodle instance". If you want me to I can look into implementing this too @superafroman. Might just be a case of scrapping all/most of the code in their `plugin.py` or create a .sh instead

#### tldr `sh makecourses.sh` does work though. 😅  exec after moodle instance is init-ed
 
The docker image for this hasn't been pushed to docker hub yet either. Will do so after merge